### PR TITLE
getStaticPathsを実装(getStaticProps実装前)

### DIFF
--- a/src/pages/posts/[id].js
+++ b/src/pages/posts/[id].js
@@ -1,12 +1,18 @@
 import Layout from "../../../conponents/Layout";
 import { getAllPostIds } from "../../../lib/post";
 
+/*getStaticPathsのために使うオブジェクトのパスをpost.jsにてparams,idで取得したので
+作ったパスをここでは取り込んでいく↓*/
 export async function getStaticPaths(){
     const paths = getAllPostIds()
-
+    //post.jsで作ったgetAllPostIds()をタブ保管で引っ張ってくる=この中にはパスがオブジェクトとして用意されているため
+    //↓以上をreturnで返していく！
     return {
         paths,
         fallback: false,
+        /*fallback: false,とすることで取ってきているpaths(getAllPostIds())に
+        含まれていない他のパスにアクセスをすると404エラーページに遷移する
+        ↑ =このパスで設定されたページはSSGされるということ！ */
     }
 }
 


### PR DESCRIPTION
getStaticPropsの実装はまだしていない為、各ブログ画面に遷移をするとエラーが出る
![Uploading スクリーンショット 2023-12-29 3.42.05.png…]()
